### PR TITLE
No forrest no xfst

### DIFF
--- a/m4/giella-macros.m4
+++ b/m4/giella-macros.m4
@@ -322,7 +322,7 @@ AC_ARG_WITH([forrest],
             [AS_HELP_STRING([--with-forrest=DIRECTORY],
                             [search forrest in DIRECTORY @<:@default=PATH@:>@])],
             [with_forrest=$withval],
-            [with_forrest=yes])
+            [with_forrest=no])
 AC_PATH_PROG([FORREST], [forrest], [], [$PATH$PATH_SEPARATOR$with_forrest])
 AC_MSG_CHECKING([whether to do forrest validation of in-source documentation])
 AS_IF([test "x$GAWK" != x], [

--- a/m4/giella-macros.m4
+++ b/m4/giella-macros.m4
@@ -431,7 +431,7 @@ AC_DEFUN([gt_PROG_XFST],
             [AS_HELP_STRING([--with-xfst=DIRECTORY],
                             [search xfst in DIRECTORY @<:@default=PATH@:>@])],
             [with_xfst=$withval],
-            [with_xfst=yes])
+            [with_xfst=no])
 AC_PATH_PROG([PRINTF], [printf], [echo -n])
 AC_PATH_PROG([XFST], [xfst], [false], [$PATH$PATH_SEPARATOR$with_xfst])
 AC_PATH_PROG([TWOLC], [twolc], [false], [$PATH$PATH_SEPARATOR$with_xfst])


### PR DESCRIPTION
This makes with-hfst and without-forrest the default.
Tested by copying giella-macros.m4 into lang-sme and doing ./autogen.sh && ./configure

The flipside of this patch is that if I set --with-xfst, I have to explicitely set --with-hfst to have hfst